### PR TITLE
Bump codeql-action to 4.37.7 (combined #248/#250/#252)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+      uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -72,4 +72,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3


### PR DESCRIPTION
Bumps all three `github/codeql-action` steps (`init`, `autobuild`, `analyze`) to 4.37.7 (`ff2f1c62`) in one commit.

CodeQL requires `init`/`autobuild`/`analyze` to run the **same** version. The individual dependabot PRs each bumped only one step, leaving the other two at 4.37.4, which fails with:

> Loaded a configuration file for version '4.37.4', but running version '4.37.7'

Bumping all three together resolves the version-consistency check. (`upload-sarif` was already bumped to 4.37.7 in #249.)

Closes #248, #250, #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)