### PR TITLE
Enforce --no-delete/--upload-only across SMB, TFTP, HTTP DELETE, WebDAV LOCK

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -49,7 +49,7 @@ was not called first, so direct callers keep working. Coverage: `httpserver`
 | HTTP(S) file server, upload, listing, preview | `httpserver/` | Core. Templates + static assets embedded (see Assets). Auth, ACL (`.goshs` dirs), bulk zip download. |
 | WebDAV | `httpserver/` (WebDav flag), separate port | `WebDavPort` default 8001 |
 | FTP / SFTP | `ftpserver/`, `sftpserver/` | `FTP`, `FTPSFTPMode`, port 2121 |
-| TFTP (UDP transfer) | `tftpserver/` | `TFTP`, port 69. Hand-rolled, dependency-free (RFC 1350 + blksize/tsize OACK). RRQ download / WRQ upload, octet only, path-traversal-safe, honours whitelist + ReadOnly/UploadOnly. Registered in mDNS (`_tftp._udp`). |
+| TFTP (UDP transfer) | `tftpserver/` | `TFTP`, port 69. Hand-rolled, dependency-free (RFC 1350 + blksize/tsize OACK). RRQ download / WRQ upload, octet only, path-traversal-safe, honours whitelist + ReadOnly/UploadOnly/NoDelete (a WRQ that would truncate an existing file is refused under `--no-delete`/`--upload-only`). Registered in mDNS (`_tftp._udp`). |
 | SMB (rogue/share + NTLM capture) | `smbserver/` | NTLM hash capture, optional wordlist cracking |
 | SMTP (rogue, attachment capture) | `smtpserver/`, `smtpattach/` | port 2525 |
 | DNS (rogue) | `dnsserver/` | port 8053 |
@@ -282,6 +282,20 @@ matching update.
   parent-dir bulk selection bypass nested `.goshs` auth/block.
 - The rogue protocol servers (SMB/LDAP/SMTP/DNS) capture credentials/NTLM by design;
   changes there have real security impact.
+- **`--no-delete` / `--upload-only` mean "no destruction of existing content" across
+  *every* write protocol** — treat overwrite (truncating open), in-place write,
+  truncate/shrink, and rename/move as deletion-class operations and refuse them for
+  pre-existing files. This invariant is enforced per-protocol and must stay in lockstep:
+  HTTP/WebDAV (`updown.go`, `webdav_acl.go` — incl. the `LOCK` verb, which plants
+  lock-null files), FTP (`noDeleteFs`), SFTP (`helper.go`), TFTP (`handleWrite`), and
+  SMB. SMB routes all four of its sinks — WRITE opcode (`handleWrite`), overwrite
+  dispositions + `Truncate` (`handleCreate`/`handleSetInfo`), and `FileRenameInformation`
+  — through `SMBServer.protectExisting(localPath)`, which returns true only when a flag
+  is set **and** the path is not in `newlyCreatedPaths` (so the operator's own
+  create→write→rename upload flow keeps working). When adding a new write path to any
+  protocol, wire this guard or you reopen the GHSA-966r/275v/jx6h/ppvh/2q29/vw29 class.
+  Regression tests: `smbserver/nodelete_test.go`, `tftpserver/tftpserver_test.go`,
+  `httpserver/webdav_modeflags_test.go`, `httpserver/handler_test.go`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ These are the awesome contributors that made `goshs` even more secure :heart:
   <td align="center"><a href="https://github.com/manus-use"><img src="https://github.com/manus-use.png?size=50" width="50" height="50"></a></td>
   <td align="center"><a href="https://github.com/shotintoeternity"><img src="https://github.com/shotintoeternity.png?size=50" width="50" height="50"></a></td>
   <td align="center"><a href="https://github.com/leanworld7-netizen"><img src="https://github.com/leanworld7-netizen.png?size=50" width="50" height="50"></a></td>
+  <td align="center"><a href="https://github.com/arbor-s"><img src="https://github.com/arbor-s.png?size=50" width="50" height="50"></a></td>
+  <td align="center"><a href="https://github.com/decsecre583"><img src="https://github.com/decsecre583.png?size=50" width="50" height="50"></a></td>
+  <td align="center"><a href="https://github.com/Forrof"><img src="https://github.com/Forrof.png?size=50" width="50" height="50"></a></td>
   <td align="center"><a href="https://github.com/wooseokdotkim">wooseokdotkim</a></td>
   <td align="center"><a href="https://github.com/Guilhem7">Guilhem7</a></td>
 </tr></table>

--- a/httpserver/handler.go
+++ b/httpserver/handler.go
@@ -892,6 +892,14 @@ func (fs *FileServer) deleteFile(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Enforce the .goshs block list: a block-listed file is treated as
+	// non-existent everywhere else (read, share, bulk, WebDAV), so deleting it
+	// must be refused too. Mirrors the read path's 404 response.
+	if slices.Contains(acl.Block, filepath.Base(deletePath)) {
+		fs.handleError(w, req, fmt.Errorf("open %s: no such file or directory", deletePath), http.StatusNotFound)
+		return
+	}
+
 	err = os.RemoveAll(deletePath)
 	if err != nil {
 		logger.Warnf("error removing %+v", deletePath)

--- a/httpserver/handler_test.go
+++ b/httpserver/handler_test.go
@@ -330,6 +330,58 @@ func TestDeleteFile_DotGoshsBlocked(t *testing.T) {
 	require.NoError(t, err, ".goshs should not have been deleted")
 }
 
+// TestDeleteFile_BlockListedRefused verifies a file block-listed by a .goshs
+// ACL cannot be deleted via HTTP DELETE — the read/share/bulk/WebDAV paths all
+// treat it as non-existent, so delete must too (regression for
+// GHSA-ppmc-5w4w-2669, residual of CVE-2026-40189).
+func TestDeleteFile_BlockListedRefused(t *testing.T) {
+	root := t.TempDir()
+	blockedDir := filepath.Join(root, "blocked")
+	require.NoError(t, os.MkdirAll(blockedDir, 0755))
+	secret := filepath.Join(blockedDir, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("TOP-SECRET"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(blockedDir, ".goshs"), []byte(`{"block":["secret.txt"]}`), 0644))
+
+	fs, cleanup := newTestFileServer(t, root)
+	defer cleanup()
+
+	r := httptest.NewRequest(http.MethodDelete, "/blocked/secret.txt", nil)
+	r.Header.Set("X-CSRF-Token", "test-csrf")
+	w := httptest.NewRecorder()
+
+	fs.deleteFile(w, r)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	_, err := os.Stat(secret)
+	require.NoError(t, err, "block-listed file must not have been deleted")
+}
+
+// TestDeleteFile_NonBlockedStillDeletable confirms the block-list guard does not
+// break ordinary deletion of a non-blocked sibling in the same directory.
+func TestDeleteFile_NonBlockedStillDeletable(t *testing.T) {
+	root := t.TempDir()
+	blockedDir := filepath.Join(root, "blocked")
+	require.NoError(t, os.MkdirAll(blockedDir, 0755))
+	keep := filepath.Join(blockedDir, "public.txt")
+	require.NoError(t, os.WriteFile(keep, []byte("hello"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(blockedDir, ".goshs"), []byte(`{"block":["secret.txt"]}`), 0644))
+
+	fs, cleanup := newTestFileServer(t, root)
+	defer cleanup()
+
+	r := httptest.NewRequest(http.MethodDelete, "/blocked/public.txt", nil)
+	r.Header.Set("X-CSRF-Token", "test-csrf")
+	w := httptest.NewRecorder()
+
+	fs.deleteFile(w, r)
+
+	// deleteFile does not set an explicit status on success (recorder defaults to
+	// 200); the meaningful signal is that the non-blocked file is gone.
+	require.Equal(t, http.StatusOK, w.Code)
+	_, err := os.Stat(keep)
+	require.True(t, os.IsNotExist(err), "non-blocked file should have been deleted")
+}
+
 // ─── CreateShareHandler edge cases ───────────────────────────────────────────
 
 func TestCreateShareHandler_InvalidExpiresInt(t *testing.T) {

--- a/httpserver/webdav_acl.go
+++ b/httpserver/webdav_acl.go
@@ -81,6 +81,17 @@ func (fs *FileServer) webdavGuard(next http.Handler) http.HandlerFunc {
 				http.Error(w, "delete disabled", http.StatusForbidden)
 				return
 			}
+		case "LOCK", "UNLOCK":
+			// LOCK is a mutating verb: golang.org/x/net/webdav's handleLock
+			// creates a "lock-null" empty file when the target path does not
+			// exist, so an unguarded LOCK plants files even under --read-only.
+			// It is not enumerated by the cases above, so without this arm it
+			// falls through and skips every mode check. Refuse it (and its
+			// UNLOCK counterpart) whenever writes are disallowed.
+			if fs.ReadOnly || fs.UploadOnly {
+				http.Error(w, "read-only", http.StatusForbidden)
+				return
+			}
 		case http.MethodGet, http.MethodHead:
 			if fs.UploadOnly {
 				http.Error(w, "upload-only", http.StatusForbidden)

--- a/httpserver/webdav_modeflags_test.go
+++ b/httpserver/webdav_modeflags_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -132,6 +133,61 @@ func TestWebdav_ReadOnly_BlocksMoveAndCopy(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, davReq(t, h, "MOVE", "/secret.txt", "/gone.txt", "").Code)
 	require.Equal(t, http.StatusForbidden, davReq(t, h, "COPY", "/secret.txt", "/copy.txt", "").Code)
 	require.Equal(t, "TOP-SECRET", fileContent(t, dir, "secret.txt"))
+}
+
+// lockReq issues a WebDAV LOCK with an exclusive-write lockinfo body.
+func lockReq(t *testing.T, h http.Handler, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	const lockInfo = `<?xml version="1.0" encoding="utf-8"?>
+<D:lockinfo xmlns:D="DAV:">
+  <D:lockscope><D:exclusive/></D:lockscope>
+  <D:locktype><D:write/></D:locktype>
+</D:lockinfo>`
+	r := httptest.NewRequest("LOCK", target, strings.NewReader(lockInfo))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+// LOCK is a mutating verb: x/net/webdav's handleLock plants a lock-null empty
+// file for an absent path, so --read-only must block it (regression for
+// GHSA-whqg-vqcj-px54). Without the guard the LOCK falls through unenumerated.
+func TestWebdav_ReadOnly_BlocksLock(t *testing.T) {
+	dir := webdavModeTree(t)
+	fs, cleanup := newTestFileServer(t, dir)
+	defer cleanup()
+	fs.ReadOnly = true
+	h := newWebdavTestHandler(fs)
+
+	w := lockReq(t, h, "/newfile.txt")
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.True(t, fileMissing(t, dir, "newfile.txt"), "LOCK must not create a lock-null file under --read-only")
+}
+
+// --upload-only likewise refuses LOCK — a lock-null empty file is not a genuine
+// upload and would let clients plant files.
+func TestWebdav_UploadOnly_BlocksLock(t *testing.T) {
+	dir := webdavModeTree(t)
+	fs, cleanup := newTestFileServer(t, dir)
+	defer cleanup()
+	fs.UploadOnly = true
+	h := newWebdavTestHandler(fs)
+
+	w := lockReq(t, h, "/newfile.txt")
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.True(t, fileMissing(t, dir, "newfile.txt"), "LOCK must not create a lock-null file under --upload-only")
+}
+
+// Control: no mode flags a LOCK works as usual — confirms the new arm does not
+// over-block normal WebDAV clients.
+func TestWebdav_Default_AllowsLock(t *testing.T) {
+	dir := webdavModeTree(t)
+	fs, cleanup := newTestFileServer(t, dir)
+	defer cleanup()
+	h := newWebdavTestHandler(fs)
+
+	w := lockReq(t, h, "/newfile.txt")
+	require.Less(t, w.Code, http.StatusBadRequest, "LOCK should succeed with no mode flags")
 }
 
 // Control: with no mode flags a MOVE works as usual — the source is renamed away

--- a/smbserver/nodelete_test.go
+++ b/smbserver/nodelete_test.go
@@ -1,0 +1,181 @@
+package smbserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// respStatus extracts the NTSTATUS from an SMB2 response (bytes 8..12).
+func respStatus(resp []byte) uint32 {
+	if len(resp) < 12 {
+		return 0xFFFFFFFF
+	}
+	return le32(resp, 8)
+}
+
+// writeFrame builds a minimal SMB2 WRITE request for the given handle ID.
+func writeFrame(hID uint64, writeOff int64, data []byte) []byte {
+	const bodyLen = 48
+	dataOff := 64 + bodyLen
+	buf := make([]byte, dataOff+len(data))
+	body := buf[64:]
+	putle16(body, 2, uint16(dataOff))   // DataOffset (from start of SMB2 header)
+	putle32(body, 4, uint32(len(data))) // Length
+	putle64(body, 8, uint64(writeOff))  // Offset
+	putle64(body, 16+8, hID)            // FileId volatile half (read at body[24])
+	copy(buf[dataOff:], data)
+	return buf
+}
+
+// TestProtectExisting exercises the shared decision helper that gates every SMB
+// --no-delete / --upload-only content-destroying sink.
+func TestProtectExisting(t *testing.T) {
+	const p = "/srv/report.docx"
+
+	t.Run("no flags never protects", func(t *testing.T) {
+		s := &SMBServer{}
+		require.False(t, s.protectExisting(p))
+	})
+
+	t.Run("no-delete protects pre-existing path", func(t *testing.T) {
+		s := &SMBServer{NoDelete: true}
+		require.True(t, s.protectExisting(p))
+	})
+
+	t.Run("upload-only protects pre-existing path", func(t *testing.T) {
+		s := &SMBServer{UploadOnly: true}
+		require.True(t, s.protectExisting(p))
+	})
+
+	t.Run("newly created path stays writable", func(t *testing.T) {
+		s := &SMBServer{NoDelete: true}
+		s.newlyCreatedPaths.Store(p, struct{}{})
+		require.False(t, s.protectExisting(p))
+	})
+}
+
+// TestHandleWrite_NoDeleteBlocksExistingFile is the regression for
+// GHSA-275v-rxgc-4rcj: an SMB2 WRITE at an attacker-chosen offset must not
+// modify a pre-existing served file when --no-delete is set.
+func TestHandleWrite_NoDeleteBlocksExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.docx")
+	original := []byte("ORIGINAL-CONTENTS")
+	require.NoError(t, os.WriteFile(path, original, 0644))
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0644)
+	require.NoError(t, err)
+	defer f.Close()
+
+	s := &SMBServer{NoDelete: true}
+	cs := newConnState()
+	hID := cs.newHandleID()
+	cs.addHandle(&smbHandle{ID: hID, Path: path, File: f})
+
+	h := &smb2Hdr{Command: SMB2_WRITE}
+	resp := s.handleWrite(cs, h, writeFrame(hID, 0, []byte("pwned")))
+
+	require.Equal(t, STATUS_ACCESS_DENIED, respStatus(resp), "WRITE to a pre-existing file must be denied under --no-delete")
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, original, got, "file contents must be untouched")
+}
+
+// TestHandleWrite_AllowsNewlyCreatedFile confirms the guard does not break
+// legitimate uploads: a file created earlier in the session (newlyCreatedPaths)
+// is still streamed via WRITE.
+func TestHandleWrite_AllowsNewlyCreatedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upload.bin")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	defer f.Close()
+
+	s := &SMBServer{NoDelete: true}
+	s.newlyCreatedPaths.Store(path, struct{}{}) // as handleCreate would record
+	cs := newConnState()
+	hID := cs.newHandleID()
+	cs.addHandle(&smbHandle{ID: hID, Path: path, File: f})
+
+	payload := []byte("fresh upload bytes")
+	h := &smb2Hdr{Command: SMB2_WRITE}
+	resp := s.handleWrite(cs, h, writeFrame(hID, 0, payload))
+
+	require.Equal(t, STATUS_SUCCESS, respStatus(resp), "WRITE to a session-created file must be allowed")
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+// renameFrame builds an SMB2 SET_INFO FileRenameInformation request renaming the
+// handle's file to newName (relative to the tree root).
+func renameFrame(hID uint64, newName string) []byte {
+	nameUTF16 := toUTF16LE(newName)
+	infoBuf := make([]byte, 20+len(nameUTF16))
+	putle32(infoBuf, 16, uint32(len(nameUTF16)))
+	copy(infoBuf[20:], nameUTF16)
+
+	const bodyLen = 32
+	bufOff := 64 + bodyLen
+	buf := make([]byte, bufOff+len(infoBuf))
+	body := buf[64:]
+	body[2] = SMB2_0_INFO_FILE
+	body[3] = FileRenameInformation
+	putle32(body, 4, uint32(len(infoBuf))) // BufferLength
+	putle16(body, 8, uint16(bufOff))       // BufferOffset (from start of SMB2 header)
+	putle64(body, 16+8, hID)               // FileId volatile half
+	copy(buf[bufOff:], infoBuf)
+	return buf
+}
+
+// TestHandleSetInfo_NoDeleteBlocksRename is the regression for
+// GHSA-ppvh-3pc7-mvxw: renaming a pre-existing file (move-as-deletion) must be
+// refused under --no-delete, mirroring FTP/SFTP/WebDAV.
+func TestHandleSetInfo_NoDeleteBlocksRename(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "keep.txt")
+	require.NoError(t, os.WriteFile(src, []byte("KEEP"), 0644))
+
+	s := &SMBServer{NoDelete: true}
+	cs := newConnState()
+	cs.addTree(&smbTree{ID: 1, ShareName: "goshs", RootPath: dir})
+	hID := cs.newHandleID()
+	cs.addHandle(&smbHandle{ID: hID, Path: src}) // pre-existing: not in newlyCreatedPaths
+
+	h := &smb2Hdr{Command: SMB2_SET_INFO, TreeID: 1}
+	resp := s.handleSetInfo(cs, h, renameFrame(hID, "moved.txt"))
+
+	require.Equal(t, STATUS_ACCESS_DENIED, respStatus(resp), "rename of a pre-existing file must be denied under --no-delete")
+	_, err := os.Stat(src)
+	require.NoError(t, err, "source must still exist at its original path")
+	require.True(t, func() bool { _, e := os.Stat(filepath.Join(dir, "moved.txt")); return os.IsNotExist(e) }(), "destination must not be created")
+}
+
+// TestHandleSetInfo_NoDeleteBlocksRenameClobber verifies that even a
+// session-created source cannot be renamed onto a pre-existing destination,
+// which os.Rename would silently clobber.
+func TestHandleSetInfo_NoDeleteBlocksRenameClobber(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "new.txt")
+	require.NoError(t, os.WriteFile(src, []byte("NEW"), 0644))
+	victim := filepath.Join(dir, "victim.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("VICTIM"), 0644))
+
+	s := &SMBServer{NoDelete: true}
+	s.newlyCreatedPaths.Store(src, struct{}{}) // source is the operator's own upload
+	cs := newConnState()
+	cs.addTree(&smbTree{ID: 1, ShareName: "goshs", RootPath: dir})
+	hID := cs.newHandleID()
+	cs.addHandle(&smbHandle{ID: hID, Path: src})
+
+	h := &smb2Hdr{Command: SMB2_SET_INFO, TreeID: 1}
+	resp := s.handleSetInfo(cs, h, renameFrame(hID, "victim.txt"))
+
+	require.Equal(t, STATUS_OBJECT_NAME_COLLISION, respStatus(resp), "rename onto an existing destination must be refused")
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	require.Equal(t, []byte("VICTIM"), got, "destination contents must be preserved")
+}

--- a/smbserver/server.go
+++ b/smbserver/server.go
@@ -1077,6 +1077,19 @@ func (s *SMBServer) handleCreate(cs *connState, h *smb2Hdr, buf []byte) []byte {
 		}
 	}
 
+	// NO-DELETE / UPLOAD-ONLY: the overwrite dispositions open an existing file
+	// with os.Create (O_TRUNC), emptying its contents. Treat truncating overwrite
+	// of a pre-existing served file as destruction and refuse it. New files
+	// (statErr != nil) and the operator's own uploads (newlyCreatedPaths) are
+	// unaffected.
+	if statErr == nil && !existing.IsDir() && s.protectExisting(localPath) {
+		switch createDisp {
+		case FILE_OVERWRITE, FILE_OVERWRITE_IF, FILE_SUPERSEDE:
+			logger.Debugf("SMB: CREATE denied (no-delete/upload-only overwrite) %s", localPath)
+			return errResp(h, STATUS_ACCESS_DENIED)
+		}
+	}
+
 	switch createDisp {
 	case FILE_OPEN:
 		if statErr != nil {
@@ -1531,6 +1544,21 @@ func (s *SMBServer) handleRead(cs *connState, h *smb2Hdr, buf []byte) []byte {
 
 // ── SMB2 Write ─────────────────────────────────────────────────────────────
 
+// protectExisting reports whether --no-delete / --upload-only must refuse a
+// content-destroying operation (in-place write, truncate, overwrite, rename)
+// on localPath. Files created earlier in this session (newlyCreatedPaths) are
+// the operator's own uploads and stay writable so Windows' create→write→rename
+// upload flow keeps working; pre-existing served files are protected. When
+// neither flag is set it always returns false, so default behaviour is
+// unchanged.
+func (s *SMBServer) protectExisting(localPath string) bool {
+	if !s.NoDelete && !s.UploadOnly {
+		return false
+	}
+	_, created := s.newlyCreatedPaths.Load(localPath)
+	return !created
+}
+
 func (s *SMBServer) handleWrite(cs *connState, h *smb2Hdr, buf []byte) []byte {
 	if len(buf) < 64+48 {
 		return errResp(h, STATUS_INVALID_PARAMETER)
@@ -1576,6 +1604,15 @@ func (s *SMBServer) handleWrite(cs *connState, h *smb2Hdr, buf []byte) []byte {
 		return resp
 	}
 	if s.ReadOnly {
+		return errResp(h, STATUS_ACCESS_DENIED)
+	}
+
+	// NO-DELETE / UPLOAD-ONLY: an SMB2 WRITE at a client-chosen offset overwrites
+	// the contents of a file in place. Treat in-place modification of a
+	// pre-existing served file as destruction and refuse it; the operator's own
+	// uploads (newlyCreatedPaths) are still streamed via WRITE after CREATE.
+	if s.protectExisting(handle.Path) {
+		logger.Debugf("SMB: WRITE denied (no-delete/upload-only, pre-existing file) %s", handle.Path)
 		return errResp(h, STATUS_ACCESS_DENIED)
 	}
 
@@ -2163,6 +2200,12 @@ func (s *SMBServer) handleSetInfo(cs *connState, h *smb2Hdr, buf []byte) []byte 
 			if len(infoBuf) < 8 || handle.File == nil {
 				return errResp(h, STATUS_INVALID_PARAMETER)
 			}
+			// NO-DELETE / UPLOAD-ONLY: Truncate shrinks a pre-existing file,
+			// destroying content. Refuse it for protected served files.
+			if s.protectExisting(handle.Path) {
+				logger.Debugf("SMB: SET_INFO FileAllocation denied (no-delete/upload-only) %s", handle.Path)
+				return errResp(h, STATUS_ACCESS_DENIED)
+			}
 			allocSize := int64(le64(infoBuf, 0))
 			if err := handle.File.Truncate(allocSize); err != nil {
 				return errResp(h, STATUS_ACCESS_DENIED)
@@ -2187,12 +2230,14 @@ func (s *SMBServer) handleSetInfo(cs *connState, h *smb2Hdr, buf []byte) []byte 
 			}
 
 		case FileRenameInformation:
-			// In upload-only mode, only allow renaming items created in this session.
-			// Windows uses a fresh FILE_OPEN handle for the rename, so we check
-			// newlyCreatedPaths (path map) rather than the handle itself.
-			if s.UploadOnly {
+			// Rename is a deletion-class operation: it moves a file out of its
+			// path (move-as-deletion) and can clobber the destination. Under
+			// --upload-only or --no-delete only allow renaming items created in
+			// this session. Windows uses a fresh FILE_OPEN handle for the rename,
+			// so we check newlyCreatedPaths (path map) rather than the handle.
+			if s.UploadOnly || s.NoDelete {
 				if _, ok := s.newlyCreatedPaths.Load(handle.Path); !ok {
-					logger.Debugf("SMB: SET_INFO FileRename denied (upload-only, pre-existing item) %s", handle.Path)
+					logger.Debugf("SMB: SET_INFO FileRename denied (no-delete/upload-only, pre-existing item) %s", handle.Path)
 					return errResp(h, STATUS_ACCESS_DENIED)
 				}
 			}
@@ -2214,6 +2259,15 @@ func (s *SMBServer) handleSetInfo(cs *connState, h *smb2Hdr, buf []byte) []byte 
 				return errResp(h, STATUS_ACCESS_DENIED)
 			}
 			oldPath := handle.Path
+			// NO-DELETE / UPLOAD-ONLY: os.Rename silently clobbers an existing
+			// destination, destroying that file's contents. Refuse to overwrite a
+			// protected pre-existing destination.
+			if s.protectExisting(newPath) {
+				if _, statErr := os.Stat(newPath); statErr == nil {
+					logger.Debugf("SMB: SET_INFO FileRename denied (no-delete/upload-only, destination exists) %s", newPath)
+					return errResp(h, STATUS_OBJECT_NAME_COLLISION)
+				}
+			}
 			if err := os.Rename(oldPath, newPath); err != nil {
 				return errResp(h, STATUS_ACCESS_DENIED)
 			}
@@ -2226,6 +2280,12 @@ func (s *SMBServer) handleSetInfo(cs *connState, h *smb2Hdr, buf []byte) []byte 
 		case FileEndOfFileInformation:
 			if len(infoBuf) < 8 || handle.File == nil {
 				return errResp(h, STATUS_INVALID_PARAMETER)
+			}
+			// NO-DELETE / UPLOAD-ONLY: setting EOF truncates a pre-existing file,
+			// destroying content. Refuse it for protected served files.
+			if s.protectExisting(handle.Path) {
+				logger.Debugf("SMB: SET_INFO FileEndOfFile denied (no-delete/upload-only) %s", handle.Path)
+				return errResp(h, STATUS_ACCESS_DENIED)
 			}
 			newSize := int64(le64(infoBuf, 0))
 			if err := handle.File.Truncate(newSize); err != nil {

--- a/tftpserver/tftpserver.go
+++ b/tftpserver/tftpserver.go
@@ -67,6 +67,7 @@ type TFTPServer struct {
 	UploadRoot string // destination for writes (WRQ): upload folder or webroot
 	ReadOnly   bool
 	UploadOnly bool
+	NoDelete   bool
 	Webhook    webhook.Webhook
 	Whitelist  *httpserver.Whitelist
 
@@ -87,6 +88,7 @@ func NewTFTPServer(opts *options.Options, wl *httpserver.Whitelist, wh webhook.W
 		UploadRoot: uploadRoot,
 		ReadOnly:   opts.ReadOnly,
 		UploadOnly: opts.UploadOnly,
+		NoDelete:   opts.NoDelete,
 		Webhook:    wh,
 		Whitelist:  wl,
 	}
@@ -242,6 +244,19 @@ func (s *TFTPServer) handleWrite(conn *net.UDPConn, client *net.UDPAddr, filenam
 		_, _ = conn.WriteToUDP(buildError(errAccessViolation, "illegal path"), client)
 		logger.Warnf("[TFTP] rejected traversal in WRQ %q from %s", filename, client.IP)
 		return
+	}
+
+	// Enforce --no-delete / --upload-only: os.Create implies O_TRUNC, so a WRQ
+	// for an existing filename would empty (destroy) its contents before any
+	// DATA arrives. Treat overwrite of an existing file as a deletion and refuse
+	// it, mirroring the HTTP/SFTP upload paths. Creating new files stays allowed.
+	if s.NoDelete || s.UploadOnly {
+		if info, statErr := os.Stat(path); statErr == nil && !info.IsDir() {
+			_, _ = conn.WriteToUDP(buildError(errAccessViolation, "overwrite of existing file not allowed"), client)
+			logger.Warnf("[TFTP] rejected overwrite of existing file %q from %s (--no-delete/--upload-only)", filename, client.IP)
+			s.HandleWebhookSend("PUT", filename, client.IP.String(), true)
+			return
+		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {

--- a/tftpserver/tftpserver_test.go
+++ b/tftpserver/tftpserver_test.go
@@ -268,6 +268,65 @@ func TestWRQRejectedWhenReadOnly(t *testing.T) {
 	}
 }
 
+// TestWRQRejectedWhenNoDeleteOverwrite verifies a WRQ for an existing filename
+// is refused under --no-delete and the original content is preserved (regression
+// for GHSA-2q29-798w-6qcp / GHSA-vw29-46p5-7h7x). os.Create implies O_TRUNC, so
+// without the guard the file would be emptied before the ACK-0 reply.
+func TestWRQRejectedWhenNoDeleteOverwrite(t *testing.T) {
+	root := t.TempDir()
+	existing := filepath.Join(root, "protected.txt")
+	original := []byte("ORIGINAL_PROTECTED_CONTENT")
+	if err := os.WriteFile(existing, original, 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	port := startServer(t, &TFTPServer{Root: root, UploadRoot: root, NoDelete: true, Whitelist: allowAll(t)})
+	c := newClient(t, port)
+
+	c.send(t, wrq("protected.txt"))
+	pkt := c.recv(t)
+	if binary.BigEndian.Uint16(pkt[:2]) != opERROR || binary.BigEndian.Uint16(pkt[2:4]) != errAccessViolation {
+		t.Fatalf("--no-delete should reject WRQ overwrite with access violation, got opcode %d code %d", binary.BigEndian.Uint16(pkt[:2]), binary.BigEndian.Uint16(pkt[2:4]))
+	}
+
+	// The file must be untouched — not truncated by the destructive open.
+	got, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatalf("existing file must survive: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("existing file was modified: got %q, want %q", got, original)
+	}
+}
+
+// TestWRQNewFileAllowedWhenNoDelete confirms --no-delete still permits creating
+// a brand-new file: the guard blocks overwrite of existing content only.
+func TestWRQNewFileAllowedWhenNoDelete(t *testing.T) {
+	root := t.TempDir()
+	port := startServer(t, &TFTPServer{Root: root, UploadRoot: root, NoDelete: true, Whitelist: allowAll(t)})
+	c := newClient(t, port)
+
+	want := []byte("fresh upload")
+	c.send(t, wrq("new.bin"))
+	ack := c.recv(t)
+	if binary.BigEndian.Uint16(ack[:2]) != opACK || binary.BigEndian.Uint16(ack[2:4]) != 0 {
+		t.Fatalf("expected ACK 0 for new file under --no-delete, got opcode %d block %d", binary.BigEndian.Uint16(ack[:2]), binary.BigEndian.Uint16(ack[2:4]))
+	}
+	c.send(t, buildData(1, want))
+	if ack := c.recv(t); binary.BigEndian.Uint16(ack[2:4]) != 1 {
+		t.Fatalf("expected ACK 1, got block %d", binary.BigEndian.Uint16(ack[2:4]))
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	got, err := os.ReadFile(filepath.Join(root, "new.bin"))
+	if err != nil {
+		t.Fatalf("new file should have been created under --no-delete: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("new file content mismatch: got %q, want %q", got, want)
+	}
+}
+
 // --- security & whitelist ---------------------------------------------------
 
 func TestRRQPathTraversalRejected(t *testing.T) {


### PR DESCRIPTION
Fixes the code behind **seven draft security advisories**. Across every write protocol, `--no-delete` / `--upload-only` now consistently treat overwrite, in-place write, truncate, and rename/move of a **pre-existing** file as deletion-class operations and refuse them — while still allowing creation of new files and the operator's own create→write→rename upload flow.

## Advisories addressed
| GHSA | Sev | Area | Fix |
|---|---|---|---|
| GHSA-275v-rxgc-4rcj | critical | SMB `WRITE` opcode | guard `handleWrite` before `WriteAt` |
| GHSA-jx6h-2x8x-hf5r | critical | SMB overwrite dispositions + `SET_INFO` truncate | guard `handleCreate` / `handleSetInfo` |
| GHSA-ppvh-3pc7-mvxw | critical | SMB `FileRenameInformation` | block rename of pre-existing + destination clobber |
| GHSA-2q29-798w-6qcp | critical | TFTP overwrite/truncate | add `NoDelete`, refuse overwrite |
| GHSA-vw29-46p5-7h7x | critical | TFTP WRQ (same root cause) | (same fix) |
| GHSA-ppmc-5w4w-2669 | high | HTTP `DELETE` block-list | enforce `.goshs` block in `deleteFile` |
| GHSA-whqg-vqcj-px54 | medium | WebDAV `LOCK` | add `LOCK`/`UNLOCK` arm to `webdavGuard` |

## SMB
Introduces `SMBServer.protectExisting(localPath)` — returns true only when a flag is set **and** the path is not in `newlyCreatedPaths` — and routes all four content-destroying sinks through it: the `WRITE` opcode, the `FILE_OVERWRITE*`/`FILE_SUPERSEDE` truncating creates, the `FileAllocation`/`FileEndOfFile` `Truncate` calls, and `FileRenameInformation` (now also gated on `NoDelete`, plus a destination-clobber check). The `newlyCreatedPaths` exception preserves Windows Explorer's create→write→rename upload pattern.

## TFTP
Adds a `NoDelete` field (plumbed from `opts.NoDelete`) and refuses a WRQ that would truncate an existing file — `os.Create` implies `O_TRUNC`, which previously emptied the target before the first DATA packet.

## HTTP DELETE
`deleteFile` now enforces the `.goshs` block list before `os.RemoveAll`, matching read/share/bulk/WebDAV. Residual of CVE-2026-40189.

## WebDAV LOCK
`webdavGuard` gained a `LOCK`/`UNLOCK` case refusing under `--read-only`/`--upload-only`; the x/net/webdav `handleLock` plants lock-null empty files for absent paths, and `LOCK` was previously unenumerated so it fell through all mode checks.

## Tests
New regression tests, each with **allow-path controls** proving the guards don't over-block legitimate new-file creation / session uploads:
- `smbserver/nodelete_test.go` — `protectExisting`, WRITE (block + allow), rename (block + clobber)
- `tftpserver/tftpserver_test.go` — overwrite blocked, new-file allowed
- `httpserver/handler_test.go` — block-listed delete refused, non-blocked still deletable
- `httpserver/webdav_modeflags_test.go` — LOCK blocked under read-only/upload-only, allowed by default

`go build ./...`, `go vet`, `gofmt`, and the full unit suite pass (integration tests require Docker and were not run).

> Note: the seven GHSA advisories remain **drafts** — not published as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)